### PR TITLE
Create ViewFarcasterProfile.tsx

### DIFF
--- a/components/ViewFarcasterProfile.tsx
+++ b/components/ViewFarcasterProfile.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import { viewProfile } from "@hellno/farcaster";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function ViewFarcasterProfile() {
+  const [input, setInput] = useState("");
+  const [profile, setProfile] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleViewProfile = async () => {
+    setLoading(true);
+    try {
+      const result = await viewProfile(input);
+      setProfile(result);
+    } catch (e) {
+      console.error("Failed to fetch profile", e);
+      setProfile(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Enter username or FID"
+        />
+        <Button onClick={handleViewProfile} disabled={loading}>
+          {loading ? "Loading..." : "View Profile"}
+        </Button>
+      </div>
+
+      {profile && (
+        <Card>
+          <CardContent className="flex items-center space-x-4 p-4">
+            <img
+              src={profile.pfp_url}
+              alt="avatar"
+              className="w-16 h-16 rounded-full"
+            />
+            <div>
+              <div className="font-bold text-lg">{profile.display_name}</div>
+              <div className="text-sm text-muted-foreground">
+                @{profile.username}
+              </div>
+              <div className="mt-1">{profile.bio?.text}</div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
#PR Description:

This PR introduces a new *ViewFarcasterProfile* component to the mini-app-ui project.

#What it does:

Adds a UI block that allows users to input a Farcaster username or FID

Uses the viewProfile method from the Farcaster SDK to fetch profile data

Displays the profile avatar, display name, username, and bio in a styled card


#Why it's useful:

Enables any mini app to quickly display a Farcaster profile with just a username or FID

Good entry point for building identity-aware mini apps

Fully self-contained and can be reused or extended


#Preview:

User enters a username like dwr.eth, presses "View Profile", and sees a card with:

PFP (rounded avatar)

Display name

@username

Bio
